### PR TITLE
Work for Version 1.2.

### DIFF
--- a/libsay
+++ b/libsay
@@ -73,17 +73,45 @@ set_border_colour() { rst; [ "$border_colour" ] && set_colour fg "$border_colour
 
 # Turns text effects on (use rst to reset).
 underline_on() { printf "\e[4m"; } # Underlines text.
+underline_off() { printf "\e[24m"; } # Disables (wavy)underline text.
 wavy_underline_on() { printf "\e[4:3m"; } # Underlines text with a squiggly underline.
 double_underline_on() { printf "\e[21m"; } # Underlines with double underline.
 overline_on() { printf "\e[53m"; } # Overlines text.
 overunder_on() { printf "\e[53m\e[4m"; } # Overlines and underlines the text.
 overuwavynder_on() { printf "\e[53m\e[4:3m"; } # Overlines and squiggly underlines the text.
+
 bold_on() {  printf "\e[1m"; } # Bold text.
-invert_on() { printf "\e[7m"; } # Swap background/foreground colours.
-blink_on() { printf "\e[6m"; } # Makes text blink.
-italics_on() { printf "\e[3m"; } # Text in italics.
-crossout_on() { printf "\e[9m"; } # Crossed out text.
+bold_off() { printf "\e[22m"; } # Turns bold and fade/dim text off.
 fade_on() { printf "\e[2m"; } # Dims text.
+fade_off() { printf "\e[22m"; } # Turns bold and fade/dim text off.
+
+invert_on() { printf "\e[7m"; } # Swap background/foreground colours.
+invert_off() { printf "\e[27m"; } # Swap back background/foreground colours.
+blink_on() { printf "\e[6m"; } # Makes text blink.
+blink_off() { printf "\e[25m"; } # Makes text stop blinking.
+
+italics_on() { printf "\e[3m"; } # Text in italics.
+italics_off() { printf "\e[23m"; } # Turns italics off.
+crossout_on() { printf "\e[9m"; } # Crossed out text.
+crossout_off() { printf "\e[29m"; } # Turns off crossed out text.
+
+fg_colour_off() { printf "\e[39m"; } # Set's foreground colour back to default.
+bg_colour_off() { printf "\e[49m"; } # Set's background colour back to default.
+
+# Text manipulation/cursor navigation.
+backspace() { printf "\b"; } # Deletes last character.
+tab() { printf "\t"; } # Inserts a tab.
+newline() { printf "\n"; } # Goes to the next line, "enter".
+v_tab() { printf "\v"; } # Adds a vertical tab.
+reset_line() { printf "\r"; } # Goes to the beginning of the line allows to add new text over the last text.
+clear_screen() { printf "\ec"; } # Clears the whole screen, similar to "clear".
+
+cursor_up() { printf "\e[1A"; } # Moves cursor one line up.
+cursor_down() { printf "\e[B"; } # Moves cursor one line down.
+cursor_right() { printf "\e[1C"; } # Moves cursor one column right.
+cursor_left() { printf "\e[1D"; } # Moves cursor one column left.
+save_pos() { printf "\e[s"; } # Save cursor's current position.
+restore_pos() { printf "\e[u"; } # Restore cursor's to saved position.
 
 # Message type parse. Colour schemes for these types of message
 c_error() { rst; bold_on; underline_on; set_colour bg white; set_colour fg red; } # Set for Error.

--- a/libsay
+++ b/libsay
@@ -73,15 +73,17 @@ set_border_colour() { rst; [ "$border_colour" ] && set_colour fg "$border_colour
 
 # Turns text effects on (use rst to reset).
 underline_on() { printf "\e[4m"; } # Underlines text.
+wavy_underline_on() { printf "\e[4:3m"; } # Underlines text with a squiggly underline.
 double_underline_on() { printf "\e[21m"; } # Underlines with double underline.
 overline_on() { printf "\e[53m"; } # Overlines text.
 overunder_on() { printf "\e[53m\e[4m"; } # Overlines and underlines the text.
+overuwavynder_on() { printf "\e[53m\e[4:3m"; } # Overlines and squiggly underlines the text.
 bold_on() {  printf "\e[1m"; } # Bold text.
 invert_on() { printf "\e[7m"; } # Swap background/foreground colours.
 blink_on() { printf "\e[6m"; } # Makes text blink.
 italics_on() { printf "\e[3m"; } # Text in italics.
 crossout_on() { printf "\e[9m"; } # Crossed out text.
-fade_on() { printf "\e[2m"; } # "Fades" text, makes it less intense.
+fade_on() { printf "\e[2m"; } # Dims text.
 
 # Message type parse. Colour schemes for these types of message
 c_error() { rst; bold_on; underline_on; set_colour bg white; set_colour fg red; } # Set for Error.
@@ -117,7 +119,8 @@ draw()
 
     # Styles, parts array will be selected according the what's set in '$style'
     # Uncomment line below to add custom styles.
-#    source styles/*.style.say
+    # source styles/*.style.say
+
     # boxdoubleline
     [ "$style" = "boxdoubleline" ] && local parts=(
     ╔ ═ ╗
@@ -223,7 +226,7 @@ say()
     {
         [ "$1" = "colour_command" ] && local options=( --colour --color )
         [ "$1" = "alignment_command" ] && local options=( --align )
-        [ "$1" = "colour" ] && local options=( black red green yellow blue magenta cyan white 
+        [ "$1" = "colour" ] && local options=( black red green yellow blue magenta cyan white
         grey light_red light_green light_yellow light_blue light_magenta light_cyan bright_white )
         [ "$1" = "alignment" ] && local options=( centre center left right )
 
@@ -444,4 +447,3 @@ say()
     unset -f text_in_a_box write_out apply_text_effect centre_text align_text_left align_text_right
     return 0
 }
-

--- a/styles/randomstar.style.say
+++ b/styles/randomstar.style.say
@@ -6,14 +6,13 @@
 # GitHub:       https://github.com/Megaf/libsay
 # License:      GPL V3
 #
-# To create your own style. Replace "randomstar" with a style name of your choice.
 #
-# The array below represents the followin.
+# The array below represents the following.
 # "top left corner" "top line" "top right corner"
 # "left side line" "right side line" "column"
 # "left side connecting line" "right side connecting line"
 # "bottom left corner" "bottom line" "bottom right corner"
-# "vertically centrered line" "bottom side connecting" "top side connecting"
+# "vertically centred line" "bottom side connecting" "top side connecting"
 # "junction"
 #
 # Example of text using the style below.

--- a/terminal_test.sh
+++ b/terminal_test.sh
@@ -188,20 +188,4 @@ esac
 unset -v start end total_time
 unset -f terminal_test ascii_test libsay_test help_menu start_timer end_timer
 
-start="$(date +%s.%3N)"
-say "INFO: Below running two empty 'say'."
-say ""
-say
-
-say "DEBUG: This is a single line Debug Message"
-
-say "TITLE: Multiline Message.
-
-INFO: The line below this one is a DEBUG one.
-DEBUG: Last line, DEBUG message."
-end="$(date +%s.%3N)"
-total_time="$(echo "scale=3; $end - $start" | bc)"
-say "INF: Total time to run the last test was "$total_time" seconds."
-unset -v start end total_time
-
 exit 0

--- a/terminal_test.sh
+++ b/terminal_test.sh
@@ -12,10 +12,21 @@
 # License:      GPL V3
 # TODO: Add md5 to check if test succeeded.
 # Prints the ASCII table.
-start=""
-start="$(date +%s.%3N)"
 
-print_ascii_table()
+start_timer()
+{
+  start=""
+  start="$(date +%s.%3N)"
+}
+
+end_timer()
+{
+  end="$(date +%s.%3N)"
+  total_time="$(echo "scale=3; $end - $start" | bc)"
+  echo "It took $total_time seconds to run the tests."
+}
+
+ascii_test()
 {
     echo "Printing the ASCII table."
     print_ascii()
@@ -37,9 +48,10 @@ print_ascii_table()
 }
 
 # Test terminals capabilities for text effects via Escape Characters.
-run_test()
+terminal_test()
 {
     local run_amount run_number
+
     echo "Testing terminal's capabilities."
     print_test()
     {
@@ -50,42 +62,49 @@ run_test()
 
     run_amount="128" # Total number of "effects" to try.
     run_number="0"
+
     printf "Testing text effects.\n"
     while [ "$run_number" -le "29" ]; do
         printf '%s' "Effect number: $run_number"
         print_test
         run_number="$((++run_number))"
     done
+
     printf "Testing normal foreground colours.\n"
     while [ "$run_number" -le "39" ]; do
         printf '%s' "Colour number: $run_number"
         print_test
         run_number="$((++run_number))"
     done
+
     printf "Testing normal background colours.\n"
     while [ "$run_number" -le "49" ]; do
         printf '%s' "Colour number: $run_number"
         print_test
         run_number="$((++run_number))"
     done
+
     printf "Testing aditional text effects.\n"
     while [ "$run_number" -le "89" ]; do
         printf '%s' "Effect number: $run_number"
         print_test
         run_number="$((++run_number))"
     done
+
     printf "Testing light foreground colours.\n"
     while [ "$run_number" -le "99" ]; do
         printf '%s' "Colour number: $run_number"
         print_test
         run_number="$((++run_number))"
     done
+
     printf "Testing light background colours.\n"
     while [ "$run_number" -le "109" ]; do
         printf '%s' "Colour number: $run_number"
         print_test
         run_number="$((++run_number))"
     done
+
     printf "Testing aditional extra effects.\n"
     while [ "$run_number" -le "$run_amount" ]; do
         printf '%s' "Effect number: $run_number"
@@ -141,15 +160,32 @@ EOM
   rst; printf '%s' "                          faded - "; fade_on;              echo -e "This is a testing text.\n"; rst
 }
 
-run_test
-print_ascii_table
-libsay_test
+__all_tests() { terminal_test && ascii_test && libsay_test; }
 
-end="$(date +%s.%3N)"
-total_time="$(echo "scale=3; $end - $start" | bc)"
-say "INFO: Total time to run the last test was $total_time seconds."
+help_menu()
+{
+  echo "┌──────────────────────────────────────────────────────┐"
+  echo "| Please run './terminal_test test_name'.              |"
+  echo "| Where 'test name' is one of the following:           |"
+  echo "├─────────────────┬────────────────────────────────────┤"
+  echo "|    Test Name    |           Description              |"
+  echo "├─────────────────┼────────────────────────────────────┤"
+  echo "| 'terminal_test' | Tests your termina's capabilities. |"
+  echo "|    'ascii_test' | Prints the ASCII Table.            |"
+  echo "|   'libsay_test' | Tests the libsay library.          |"
+  echo "|           'all' | Runs all of the above.             |"
+  echo "└─────────────────┴────────────────────────────────────┘"
+}
+
+case "$*" in
+  terminal_test)  start_timer; terminal_test; end_timer  ;;
+     ascii_test)  start_timer;    ascii_test; end_timer  ;;
+    libsay_test)  start_timer;   libsay_test; end_timer  ;;
+            all)  start_timer;   __all_tests; end_timer  ;;
+              *)                              help_menu  ;;
+esac
 
 unset -v start end total_time
-unset -f run_test print_ascii_table libsay_test
+unset -f terminal_test ascii_test libsay_test help_menu start_timer end_timer
 
 exit 0

--- a/terminal_test.sh
+++ b/terminal_test.sh
@@ -100,8 +100,8 @@ run_test()
 libsay_test()
 {
   local test_message debug
-  # shellcheck source=./libsay
-  source ./libsay
+  # shellcheck source=/dev/null
+  source libsay
   say "TITLE: The following test uses libsays's functions."
   draw do_godown
   debug="false";

--- a/terminal_test.sh
+++ b/terminal_test.sh
@@ -10,8 +10,11 @@
 # Date:         21/09/2022
 # GitHub:       https://github.com/Megaf/libsay
 # License:      GPL V3
-
+# TODO: Add md5 to check if test succeeded.
 # Prints the ASCII table.
+start=""
+start="$(date +%s.%3N)"
+
 print_ascii_table()
 {
     echo "Printing the ASCII table."
@@ -28,7 +31,7 @@ print_ascii_table()
 
     for i in {128..254}; do
         print_ascii "$i"
-    done     
+    done
     unset -v character command i
     unset -f print_ascii
 }
@@ -36,6 +39,7 @@ print_ascii_table()
 # Test terminals capabilities for text effects via Escape Characters.
 run_test()
 {
+    local run_amount run_number
     echo "Testing terminal's capabilities."
     print_test()
     {
@@ -44,56 +48,108 @@ run_test()
         printf "\n"
     }
 
-    local run_amount="128" # Total number of "effects" to try.
-    local run_number="0"
+    run_amount="128" # Total number of "effects" to try.
+    run_number="0"
     printf "Testing text effects.\n"
     while [ "$run_number" -le "29" ]; do
         printf '%s' "Effect number: $run_number"
         print_test
-        local run_number="$((++run_number))"
+        run_number="$((++run_number))"
     done
     printf "Testing normal foreground colours.\n"
     while [ "$run_number" -le "39" ]; do
         printf '%s' "Colour number: $run_number"
         print_test
-        local run_number="$((++run_number))"
+        run_number="$((++run_number))"
     done
     printf "Testing normal background colours.\n"
     while [ "$run_number" -le "49" ]; do
         printf '%s' "Colour number: $run_number"
         print_test
-        local run_number="$((++run_number))"
+        run_number="$((++run_number))"
     done
     printf "Testing aditional text effects.\n"
     while [ "$run_number" -le "89" ]; do
         printf '%s' "Effect number: $run_number"
         print_test
-        local run_number="$((++run_number))"
+        run_number="$((++run_number))"
     done
     printf "Testing light foreground colours.\n"
     while [ "$run_number" -le "99" ]; do
         printf '%s' "Colour number: $run_number"
         print_test
-        local run_number="$((++run_number))"
+        run_number="$((++run_number))"
     done
     printf "Testing light background colours.\n"
     while [ "$run_number" -le "109" ]; do
         printf '%s' "Colour number: $run_number"
         print_test
-        local run_number="$((++run_number))"
+        run_number="$((++run_number))"
     done
     printf "Testing aditional extra effects.\n"
     while [ "$run_number" -le "$run_amount" ]; do
         printf '%s' "Effect number: $run_number"
         print_test
-        local run_number="$((++run_number))"
+        run_number="$((++run_number))"
     done
+
     unset -v run_amount run_number
-    unset -f print_test
+    unset -f print_test f
+}
+
+libsay_test()
+{
+  local test_message debug
+  # shellcheck source=./libsay
+  source ./libsay
+  say "TITLE: The following test uses libsays's functions."
+  draw do_godown
+  debug="false";
+  say "NOTICE: 'debug=$debug'"
+  read -r -d '' test_message << EOM
+TITLE: Multiline Message.
+
+A normal unformatted text.
+NOTICE: Please notice this!
+WARNING: I'm warning you...
+ERROR: Nothing wrong happened.
+
+INFO: The line below this one is a DEBUG one.
+DEBUG: Last line, DEBUG message.
+EOM
+
+  rst; say "$test_message"; rst
+  draw do_godown
+  debug="true";
+  say "NOTICE: 'debug=$debug'"
+  rst; say "$test_message"; rst
+  unset -v test_message debug
+
+  draw do_godown
+  say "TITLE: Testing text formating using libsay's '_on' functions."
+  rst; printf '%s' "                      underline - "; underline_on;         echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "             squiggly underline - "; wavy_underline_on;    echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "               double underline - "; double_underline_on;  echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "                       overline - "; overline_on;          echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "         underline and overline - "; overunder_on;         echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "underline and squiggly overline - "; overuwavynder_on;     echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "                           bold - "; bold_on;              echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "                       inverted - "; invert_on;            echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "                       blinking - "; blink_on;             echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "                        italics - "; italics_on;           echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "                 strike-through - "; crossout_on;          echo -e "This is a testing text.\n"; rst
+  rst; printf '%s' "                          faded - "; fade_on;              echo -e "This is a testing text.\n"; rst
 }
 
 run_test
 print_ascii_table
-unset -f run_test print_ascii_table
+libsay_test
+
+end="$(date +%s.%3N)"
+total_time="$(echo "scale=3; $end - $start" | bc)"
+say "INFO: Total time to run the last test was $total_time seconds."
+
+unset -v start end total_time
+unset -f run_test print_ascii_table libsay_test
 
 exit 0


### PR DESCRIPTION
On [libsay](https://github.com/Megaf/libsay/blob/stable/libsay)
* Added ability to turn off the following effects individually:
  * underline
  * bold/fade
  * italics
  * foreground colour
  * background colour.
* Added new text effects:
  * wavy_underline - Adds a squiggly underline.
  * overuwavynder - Uses a squiggly underline with a straight overline.
* Added new screen/text manipulation:
  * backspace - Deletes last character on the line the command was ran from.
  * tab - Adds terminal tab space.
  * v_tab - Adds a vertical tab.
  * newline - Adds line-break, (alternative  to `draw do_godown` and `printf '\n'.
  * reset_line - Moves cursor to the beginning and allows to overwrite it.
  * clear_screen - Clears the screen.
* Added cursor movement/navigation:
  * cursor_(up/down/left/right) - Moves cursor around columns and lines.
  * save_pos - Saves current cursor position.
  * restore_pos - Returns to saved position.
* Corrected spelling mistakes.

On [terminal_test.sh](https://github.com/Megaf/libsay/blob/stable/terminal_test.sh)
* Corrected spelling mistakes.
* Moved around and fixed functions and timers.